### PR TITLE
Data disk issue 220420

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -29,6 +29,18 @@ echo "Turning off firewalld"
 systemctl stop firewalld
 systemctl disable firewalld
 
+#Format and mount the data disk to /var/lib/neo4j
+MOUNT_POINT="/var/lib/neo4j"
+
+sudo parted /dev/sdc --script mklabel gpt mkpart xfspart xfs 0% 100%
+sudo mkfs.xfs /dev/sdc1
+sudo partprobe /dev/sdc1
+mkdir $MOUNT_POINT
+
+DATA_DISK_UUID=$(blkid | grep sdc | awk {'print $2'} | sed s/\"//g)
+echo "$DATA_DISK_UUID $MOUNT_POINT xfs defaults 0 0" >> /etc/fstab
+mount -a
+
 echo Adding neo4j yum repo...
 rpm --import https://debian.neo4j.com/neotechnology.gpg.key
 echo "

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -39,6 +39,8 @@ mkdir $MOUNT_POINT
 
 DATA_DISK_UUID=$(blkid | grep sdc | awk {'print $2'} | sed s/\"//g)
 echo "$DATA_DISK_UUID $MOUNT_POINT xfs defaults 0 0" >> /etc/fstab
+
+systemctl daemon-reload
 mount -a
 
 echo Adding neo4j yum repo...

--- a/simple/mainTemplate.json
+++ b/simple/mainTemplate.json
@@ -170,7 +170,7 @@
               "dataDisks": [
                 {
                   "lun": 0,
-                  "createOption": "Empty",
+                  "createOption": "attach",
                   "managedDisk": {
                     "storageAccountType": "Premium_LRS"
                   },


### PR DESCRIPTION
This change should leave the data disk intact and mount it at /var/lib/neo4j.  Whilst using separate data disks wouldn't be my preference, it seems to be common practise in Azure.  The net result here should mean that /var/lib/neo4j (which contains) the database is created to the size specified by the user during setup.